### PR TITLE
fix(telegram): fix telegram icon

### DIFF
--- a/apps/telegram/Dockerfile
+++ b/apps/telegram/Dockerfile
@@ -11,10 +11,12 @@ RUN \
   echo '[Desktop Entry]' > /usr/share/applications/telegram-pa.desktop && \
   echo 'Name=Telegram PA' >> /usr/share/applications/telegram-pa.desktop && \
   echo 'Exec=/bin/sh -c "$HOME/.local/bin/proot-apps run ghcr.io/'${REPO}':telegram %U"' >> /usr/share/applications/telegram-pa.desktop && \
-  echo 'Icon=telegram' >> /usr/share/applications/telegram-pa.desktop && \
+  echo 'Icon=org.telegram.desktop' >> /usr/share/applications/telegram-pa.desktop && \
   echo 'Terminal=false' >> /usr/share/applications/telegram-pa.desktop && \
   echo 'Type=Application' >> /usr/share/applications/telegram-pa.desktop && \
   echo 'MimeType=x-scheme-handler/tg;' >> /usr/share/applications/telegram-pa.desktop && \
+  echo 'Categories=Chat;Network;InstantMessaging;Qt;' >> /usr/share/applications/telegram-pa.desktop && \
+  echo 'Keywords=tg;chat;im;messaging;messenger;sms;tdesktop;' >> /usr/share/applications/telegram-pa.desktop && \
   echo "**** set bin name ****" && \
   echo "telegram-pa" > /bin-name && \
   echo "**** cleanup ****" && \

--- a/apps/telegram/install
+++ b/apps/telegram/install
@@ -4,7 +4,7 @@
 echo "Adding icon"
 mkdir -p $HOME/.local/share/icons/hicolor/scalable/apps/
 cp \
-  /usr/share/icons/hicolor/256x256/apps/telegram.png \
+  /usr/share/icons/hicolor/256x256/apps/org.telegram.desktop.png \
   $HOME/.local/share/icons/hicolor/scalable/apps/
 echo "Adding start menu entry"
 mkdir -p $HOME/.local/share/applications/

--- a/apps/telegram/remove
+++ b/apps/telegram/remove
@@ -1,6 +1,6 @@
 #!/bin/bash
 echo "Removing icon"
-rm -f $HOME/.local/share/icons/hicolor/scalable/apps/telegram.png
+rm -f $HOME/.local/share/icons/hicolor/scalable/apps/org.telegram.desktop.png
 echo "Removing start menu entry"
 rm -f $HOME/.local/share/applications/telegram-pa.desktop
 echo "Removing desktop shortcut"


### PR DESCRIPTION
Due to tdesktop using app ID as icon name after this [commit](https://github.com/telegramdesktop/tdesktop/commit/228bbc1e8e6963708563ff12d2e4b9004bed1b88), the icon is missing in the latest release pa image.

This PR is to fix this issue.

<img width="887" height="237" alt="SCR-20260412-mzja" src="https://github.com/user-attachments/assets/3aef3da7-9915-4015-9eaa-f21f01b4e50e" />
