### PR TITLE
fix(obsidian): Add locales-all package to fix broken external non-ASCII links

### DIFF
--- a/apps/obsidian/Dockerfile
+++ b/apps/obsidian/Dockerfile
@@ -12,6 +12,7 @@ RUN \
     libatk1.0 \
     libatk-bridge2.0 \
     libnss3 \
+    locales-all \
     python3-xdg && \
   OBSIDIAN_VERSION=$(curl -sX GET "https://api.github.com/repos/obsidianmd/obsidian-releases/releases/latest"| awk '/tag_name/{print $4;exit}' FS='[""]') && \
   OBSIDIAN_NOV=$(echo ${OBSIDIAN_VERSION} | sed 's/v//g') && \


### PR DESCRIPTION
Images fail to display if stored in non-ASCII folders or paths. Tested on VS Code with no issues.

<img width="699" height="482" alt="SCR-20260411-ldgj" src="https://github.com/user-attachments/assets/9cc55dd2-c260-4e87-a94e-894f6e32f292" />

I found the root cause is a missing locale. I installed the `locales` package and used the `localedef` tool to generate the locale specified by `$LC_ALL` with the command:

```bash
localedef -i zh_CN -f UTF-8 zh_CN.UTF-8
```

After restarting obsidian-pa, the issue was resolved.

This PR uses the simplest way to fix this issue: installing the `locales-all` package.

`locales-all` includes all global locales, so there is no need to handle the `$LC_ALL` variable or compile new locales in the install script. 

Perhaps compiling locales during the installation step would be better. If needed, I can update this PR accordingly.