### PR TITLE
fix: add container-safe flags to Edge entrypoint

### DIFF
--- a/apps/edge/entrypoint
+++ b/apps/edge/entrypoint
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Start Edge
-microsoft-edge --no-sandbox --test-type "$@"
+microsoft-edge --no-sandbox --test-type --disable-dev-shm-usage --disable-gpu "$@"


### PR DESCRIPTION
Add --disable-dev-shm-usage and --disable-gpu to prevent crashes in webtop/container environments where /dev/shm is limited and no GPU is available.